### PR TITLE
OTEL's metricName() was silently dropping the subsystem

### DIFF
--- a/otel.go
+++ b/otel.go
@@ -200,6 +200,9 @@ func (r *otelReporter) metricName(path string) string {
 	if r.namespace != "" {
 		return fmt.Sprintf("%s_%s", r.namespace, path)
 	}
+	if r.subSystem != "" {
+		return fmt.Sprintf("%s_%s", r.subSystem, path)
+	}
 	return path
 }
 


### PR DESCRIPTION
OTEL's metricName() was silently dropping the subsystem when no system/namespace was set